### PR TITLE
now using dotMorten.Microsoft.SqlServer.Types for .NET standard

### DIFF
--- a/SqlServerToCouchbase/SqlServerToCouchbase.csproj
+++ b/SqlServerToCouchbase/SqlServerToCouchbase.csproj
@@ -12,10 +12,11 @@
   <ItemGroup>
     <PackageReference Include="CouchbaseNetClient" Version="3.1.4" />
     <PackageReference Include="Dapper" Version="2.0.78" />
+    <PackageReference Include="dotMorten.Microsoft.SqlServer.Types" Version="1.3.0" />
     <PackageReference Include="Dynamitey" Version="2.0.10.189" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Microsoft.SqlServer.Types" Version="14.0.1016.290" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
+    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
updated to use dotMorten.Microsoft.SqlServer.Types (which is a .NET Standard library) instead of Microsoft.SqlServer.Types (which is a .NETFramework library).